### PR TITLE
Fix availability check

### DIFF
--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -152,13 +152,12 @@ public class RealtimeClient: TransportDelegate {
     // MARK: - Initialization
 
     // ----------------------------------------------------------------------
-//    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(endPoint: String,
                 params: [String: Any]? = nil)
     {
         endPointUrl = RealtimeClient.buildEndpointUrl(endpoint: endPoint,
                                                       params: params)
-        if #available(OSX 10.15, *) {
+        if #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) {
             transport = URLSessionTransport(url: endPointUrl)
         } else {
             transport = StarscreamTransport(url: endPointUrl)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix availability check for `URLSessionTransport`.

## What is the current behavior?

The current availability check consider only macOS versions.

## What is the new behavior?

Availability check now consider macOS, iOS, tvOS and watchOS versions.