### PR TITLE
Swiftification of the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ let allChanges = client.channel(.all)
 allChanges.on(.all) { message in
     print(message)
 }
+allChanges.subscribe()
+// ...
+allChanges.unsubscribe()
 allChanges.off(.all)
 ```
 
@@ -62,6 +65,9 @@ let allPublicInsertChanges = client.channel(.schema("public"))
 allPublicInsertChanges.on(.insert) { message in
     print(message)
 }
+allPublicInsertChanges.subscribe()
+// ...
+allPublicInsertChanges.unsubscribe()
 allPublicInsertChanges.off(.insert)
 ```
 
@@ -72,6 +78,9 @@ let allUsersUpdateChanges = client.channel(.table("users", schema: "public"))
 allUsersUpdateChanges.on(.update) { message in
     print(message)
 }
+allUsersUpdateChanges.subscribe()
+// ...
+allUsersUpdateChanges.unsubscribe()
 allUsersUpdateChanges.off(.update)
 ```
 
@@ -82,6 +91,9 @@ let allUserId99Changes = client.channel(.column("id", value: "99", table: "users
 allUserId99Changes.on(.all){ message in
     print(message)
 }
+allUserId99Changes.subscribe()
+// ...
+allUserId99Changes.unsubscribe()
 allUserId99Changes.off(.all)
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ client.connect()
 **Socket Hooks**
 
 ```swift
-socket.onOpen { 
+client.onOpen {
     print("Socket opened.")
 }
 
-socket.onError { error in
+client.onError { error in
     print("Socket error: ", error.localizedDescription)
 }
 
-socket.onClose {
+client.onClose {
     print("Socket closed")
 }
 ```
@@ -41,10 +41,55 @@ Call `disconnect()` on the socket:
 client.disconnect()
 ```
 
+### Subscribe to topics
+
+You can subscribe to all topic, or to specific schema parts.
+
+* Listen to all database changes:
+
+```swift
+let allChanges = client.channel(.all)
+allChanges.on(.all) { message in
+    print(message)
+}
+allChanges.off(.all)
+```
+
+* Listen to a specific schema's changes:
+
+```swift
+let allPublicInsertChanges = client.channel(.schema("public"))
+allPublicInsertChanges.on(.insert) { message in
+    print(message)
+}
+allPublicInsertChanges.off(.insert)
+```
+
+* Listen to a specific table's changes:
+
+```swift
+let allUsersUpdateChanges = client.channel(.table("users", schema: "public"))
+allUsersUpdateChanges.on(.update) { message in
+    print(message)
+}
+allUsersUpdateChanges.off(.update)
+```
+
+* Listen to a specific column's value changes:
+
+```swift
+let allUserId99Changes = client.channel(.column("id", value: "99", table: "users", schema: "public"))
+allUserId99Changes.on(.all){ message in
+    print(message)
+}
+allUserId99Changes.off(.all)
+```
+
+
 ## Credits
 
-- https://github.com/supabase/realtime-js 
-- https://github.com/davidstump/SwiftPhoenixClient 
+- https://github.com/supabase/realtime-js
+- https://github.com/davidstump/SwiftPhoenixClient
 
 ## License
 

--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -476,7 +476,7 @@ public class Channel {
     ///
     /// Example:
     ////
-    ///     channel.leave().receive("ok") { _ in { print("left") }
+    ///     channel.unsubscribe().receive("ok") { _ in { print("left") }
     ///
     /// - parameter timeout: Optional timeout
     /// - return: Push that can add receive hooks

--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -57,8 +57,8 @@ struct Binding {
 import Foundation
 
 public class Channel {
-    /// The topic of the Channel. e.g. "rooms:friends"
-    public let topic: String
+    /// The topic of the Channel. e.g. `.table("rooms", "friends")`
+    public let topic: ChannelTopic
 
     /// The params sent when joining the channel
     public var params: [String: Any] {
@@ -100,7 +100,7 @@ public class Channel {
     /// - parameter topic: Topic of the Channel
     /// - parameter params: Optional. Parameters to send when joining.
     /// - parameter socket: Socket that the channel is a part of
-    init(topic: String, params: [String: Any] = [:], socket: RealtimeClient) {
+    init(topic: ChannelTopic, params: [String: Any] = [:], socket: RealtimeClient) {
         state = ChannelState.closed
         self.topic = topic
         self.params = params

--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -24,7 +24,7 @@ import Swift
 /// Container class of bindings to the channel
 struct Binding {
     // The event that the Binding is bound to
-    let event: String
+    let event: ChannelEvent
 
     // The reference number of the Binding
     let ref: Int
@@ -217,7 +217,7 @@ public class Channel {
         // Perform when the join reply is received
         delegateOn(ChannelEvent.reply, to: self) { (self, message) in
             // Trigger bindings
-            self.trigger(event: self.replyEventName(message.ref),
+            self.trigger(event: ChannelEvent.channelReply(message.ref),
                          payload: message.payload,
                          ref: message.ref,
                          joinRef: message.joinRef)
@@ -340,13 +340,13 @@ public class Channel {
     /// Example:
     ///
     ///     let channel = socket.channel("topic")
-    ///     let ref1 = channel.on("event") { [weak self] (message) in
+    ///     let ref1 = channel.on(.all) { [weak self] (message) in
     ///         self?.print("do stuff")
     ///     }
-    ///     let ref2 = channel.on("event") { [weak self] (message) in
+    ///     let ref2 = channel.on(.all) { [weak self] (message) in
     ///         self?.print("do other stuff")
     ///     }
-    ///     channel.off("event", ref1)
+    ///     channel.off(.all, ref1)
     ///
     /// Since unsubscription of ref1, "do stuff" won't print, but "do other
     /// stuff" will keep on printing on the "event"
@@ -355,7 +355,7 @@ public class Channel {
     /// - parameter callback: Called with the event's message
     /// - return: Ref counter of the subscription. See `func off()`
     @discardableResult
-    public func on(_ event: String, callback: @escaping ((Message) -> Void)) -> Int {
+    public func on(_ event: ChannelEvent, callback: @escaping ((Message) -> Void)) -> Int {
         var delegated = Delegated<Message, Void>()
         delegated.manuallyDelegate(with: callback)
 
@@ -371,23 +371,23 @@ public class Channel {
     /// Example:
     ///
     ///     let channel = socket.channel("topic")
-    ///     let ref1 = channel.delegateOn("event", to: self) { (self, message) in
+    ///     let ref1 = channel.delegateOn(.all, to: self) { (self, message) in
     ///         self?.print("do stuff")
     ///     }
-    ///     let ref2 = channel.delegateOn("event", to: self) { (self, message) in
+    ///     let ref2 = channel.delegateOn(.all, to: self) { (self, message) in
     ///         self?.print("do other stuff")
     ///     }
-    ///     channel.off("event", ref1)
+    ///     channel.off(.all, ref1)
     ///
     /// Since unsubscription of ref1, "do stuff" won't print, but "do other
-    /// stuff" will keep on printing on the "event"
+    /// stuff" will keep on printing on all "event" (*).
     ///
     /// - parameter event: Event to receive
     /// - parameter owner: Class registering the callback. Usually `self`
     /// - parameter callback: Called with the event's message
     /// - return: Ref counter of the subscription. See `func off()`
     @discardableResult
-    public func delegateOn<Target: AnyObject>(_ event: String,
+    public func delegateOn<Target: AnyObject>(_ event: ChannelEvent,
                                               to owner: Target,
                                               callback: @escaping ((Target, Message) -> Void)) -> Int
     {
@@ -399,7 +399,7 @@ public class Channel {
 
     /// Shared method between `on` and `manualOn`
     @discardableResult
-    private func on(_ event: String, delegated: Delegated<Message, Void>) -> Int {
+    private func on(_ event: ChannelEvent, delegated: Delegated<Message, Void>) -> Int {
         let ref = bindingRef
         bindingRef = ref + 1
 
@@ -414,19 +414,19 @@ public class Channel {
     /// Example:
     ///
     ///     let channel = socket.channel("topic")
-    ///     let ref1 = channel.on("event") { _ in print("ref1 event" }
-    ///     let ref2 = channel.on("event") { _ in print("ref2 event" }
-    ///     let ref3 = channel.on("other_event") { _ in print("ref3 other" }
-    ///     let ref4 = channel.on("other_event") { _ in print("ref4 other" }
-    ///     channel.off("event", ref1)
-    ///     channel.off("other_event")
+    ///     let ref1 = channel.on(.insert) { _ in print("ref1 event" }
+    ///     let ref2 = channel.on(.insert) { _ in print("ref2 event" }
+    ///     let ref3 = channel.on(.update) { _ in print("ref3 other" }
+    ///     let ref4 = channel.on(.update) { _ in print("ref4 other" }
+    ///     channel.off(.insert, ref1)
+    ///     channel.off(.update)
     ///
     /// After this, only "ref2 event" will be printed if the channel receives
-    /// "event" and nothing is printed if the channel receives "other_event".
+    /// "insert" and nothing is printed if the channel receives "update".
     ///
     /// - parameter event: Event to unsubscribe from
     /// - paramter ref: Ref counter returned when subscribing. Can be omitted
-    public func off(_ event: String, ref: Int? = nil) {
+    public func off(_ event: ChannelEvent, ref: Int? = nil) {
         bindingsDel.removeAll { (bind) -> Bool in
             bind.event == event && (ref == nil || ref == bind.ref)
         }
@@ -437,14 +437,14 @@ public class Channel {
     /// Example:
     ///
     ///     channel
-    ///         .push("event", payload: ["message": "hello")
+    ///         .push(.update, payload: ["message": "hello")
     ///         .receive("ok") { _ in { print("message sent") }
     ///
     /// - parameter event: Event to push
     /// - parameter payload: Payload to push
     /// - parameter timeout: Optional timeout
     @discardableResult
-    public func push(_ event: String,
+    public func push(_ event: ChannelEvent,
                      payload: [String: Any],
                      timeout: TimeInterval = Defaults.timeoutInterval) -> Push
     {
@@ -578,13 +578,13 @@ public class Channel {
     }
 
     /// Triggers an event to the correct event bindings created by
-    //// `channel.on("event")`.
+    //// `channel.on(event)`.
     ///
     /// - parameter event: Event to trigger
     /// - parameter payload: Payload of the event
     /// - parameter ref: Ref of the event. Defaults to empty
     /// - parameter joinRef: Ref of the join event. Defaults to nil
-    func trigger(event: String,
+    func trigger(event: ChannelEvent,
                  payload: [String: Any] = [:],
                  ref: String = "",
                  joinRef: String? = nil)
@@ -595,12 +595,6 @@ public class Channel {
                               payload: payload,
                               joinRef: joinRef ?? self.joinRef)
         trigger(message)
-    }
-
-    /// - parameter ref: The ref of the event push
-    /// - return: The event name of the reply
-    func replyEventName(_ ref: String) -> String {
-        return "chan_reply_\(ref)"
     }
 
     /// The Ref send during the join message.

--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -68,19 +68,71 @@ public enum ChannelState: String {
 }
 
 /// Represents the different events that can be sent through
-/// a channel regarding a Channel's lifecycle.
+/// a channel regarding a Channel's lifecycle or
+/// that can be registered to be notified of.
 public enum ChannelEvent {
-    public static let heartbeat = "heartbeat"
-    public static let join = "phx_join"
-    public static let leave = "phx_leave"
-    public static let reply = "phx_reply"
-    public static let error = "phx_error"
-    public static let close = "phx_close"
+    case heartbeat
+    case join
+    case leave
+    case reply
+    case error
+    case close
 
-    static func isLifecyleEvent(_ event: String) -> Bool {
-        switch event {
-        case join, leave, reply, error, close: return true
-        default: return false
+    case all
+    case insert
+    case update
+    case delete
+
+    case channelReply(String)
+
+    public var raw: String {
+        switch self {
+        case .heartbeat: return "heartbeat"
+        case .join: return "phx_join"
+        case .leave: return "phx_leave"
+        case .reply: return "phx_reply"
+        case .error: return "phx_error"
+        case .close: return "phx_close"
+
+        case .all: return "*"
+        case .insert: return "insert"
+        case .update: return "update"
+        case .delete: return "delete"
+
+        case .channelReply(let reference): return "chan_reply_\(reference)"
         }
+    }
+
+    public init?(from type: String) {
+        switch type {
+        case "heartbeat": self = .heartbeat
+        case "phx_join": self = .join
+        case "phx_leave": self = .leave
+        case "phx_reply": self = .reply
+        case "phx_error": self = .error
+        case "phx_close": self = .close
+        case  "*": self = .all
+        case "insert": self = .insert
+        case "update": self = .update
+        case "delete": self = .delete
+        default: return nil
+        }
+    }
+
+
+    static func isLifecyleEvent(_ event: ChannelEvent) -> Bool {
+        switch event {
+        case .join, .leave, .reply, .error, .close: return true
+        case .all, .insert, .update, .delete: return false
+        // Most likely new events will be about notification
+        // not about lifecycle.
+        @unknown default: return false
+        }
+    }
+}
+
+extension ChannelEvent: Equatable {
+    public static func ==(lhs: ChannelEvent, rhs: ChannelEvent) -> Bool {
+        return lhs.raw == rhs.raw
     }
 }

--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -104,7 +104,7 @@ public enum ChannelEvent {
     }
 
     public init?(from type: String) {
-        switch type {
+        switch type.lowercased() {
         case "heartbeat": self = .heartbeat
         case "phx_join": self = .join
         case "phx_leave": self = .leave

--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -141,18 +141,18 @@ extension ChannelEvent: Equatable {
 // a channel can subscribe to.
 public enum ChannelTopic {
     case all
-    case schema(schema: String)
-    case table(schema: String, table: String)
-    case column(schema: String, table: String, column: String, value: String)
+    case schema(_ schema: String)
+    case table(_ table: String, schema: String)
+    case column(_ column: String, value: String, table: String, schema: String)
 
     case heartbeat
 
     public var raw: String {
         switch self {
         case .all: return "realtime:*"
-        case .schema(let table): return "realtime:\(table)"
-        case .table(let schema, let table): return "realtime:\(schema):\(table)"
-        case .column(let schema, let table, let column, let value): return "realtime:\(schema):\(table):\(column)=eq.\(value)"
+        case .schema(let name): return "realtime:\(name)"
+        case .table(let tableName, let schema): return "realtime:\(schema):\(tableName)"
+        case .column(let columnName, let value, let table, let schema): return "realtime:\(schema):\(table):\(columnName)=eq.\(value)"
         case .heartbeat: return "phoenix"
         }
     }
@@ -166,14 +166,14 @@ public enum ChannelTopic {
             let parts = type.split(separator: ":")
             switch parts.count {
             case 1:
-                self = .schema(schema: String(parts[0]))
+                self = .schema(String(parts[0]))
             case 2:
-                self = .table(schema: String(parts[0]), table: String(parts[1]))
+                self = .table(String(parts[1]), schema: String(parts[0]))
             case 3:
                 let condition = parts[2].split(separator: "=")
                 if condition.count == 2,
                     condition[1].hasPrefix("eq.") {
-                    self = .column(schema: String(parts[0]), table: String(parts[1]), column: String(condition[0]), value: String(condition[1].dropFirst(3)))
+                    self = .column(String(condition[0]), value: String(condition[1].dropFirst(3)), table: String(parts[1]), schema: String(parts[0]))
                 } else {
                     return nil
                 }

--- a/Sources/Realtime/Message.swift
+++ b/Sources/Realtime/Message.swift
@@ -32,7 +32,7 @@ public class Message {
     public let topic: String
 
     /// Message event
-    public let event: String
+    public let event: ChannelEvent
 
     /// Message payload
     public var payload: [String: Any]
@@ -47,7 +47,7 @@ public class Message {
 
     init(ref: String = "",
          topic: String = "",
-         event: String = "",
+         event: ChannelEvent = .all,
          payload: [String: Any] = [:],
          joinRef: String? = nil)
     {
@@ -68,7 +68,7 @@ public class Message {
             let payload = json["payload"] as? [String: Any]
         {
             self.topic = topic
-            self.event = event
+            self.event = ChannelEvent(from: event) ?? .all
             self.payload = payload
         } else {
             return nil

--- a/Sources/Realtime/Message.swift
+++ b/Sources/Realtime/Message.swift
@@ -29,7 +29,7 @@ public class Message {
     internal let joinRef: String?
 
     /// Message topic
-    public let topic: String
+    public let topic: ChannelTopic
 
     /// Message event
     public let event: ChannelEvent
@@ -46,7 +46,7 @@ public class Message {
     }
 
     init(ref: String = "",
-         topic: String = "",
+         topic: ChannelTopic = .all,
          event: ChannelEvent = .all,
          payload: [String: Any] = [:],
          joinRef: String? = nil)
@@ -67,7 +67,7 @@ public class Message {
             let event = json["event"] as? String,
             let payload = json["payload"] as? [String: Any]
         {
-            self.topic = topic
+            self.topic = ChannelTopic(from: topic) ?? .all
             self.event = ChannelEvent(from: event) ?? .all
             self.payload = payload
         } else {

--- a/Sources/Realtime/Push.swift
+++ b/Sources/Realtime/Push.swift
@@ -93,7 +93,7 @@ public class Push {
         startTimeout()
         sent = true
         channel?.socket?.push(
-            topic: channel?.topic ?? "",
+            topic: channel?.topic ?? .all,
             event: event,
             payload: payload,
             ref: ref,

--- a/Sources/Realtime/Push.swift
+++ b/Sources/Realtime/Push.swift
@@ -25,8 +25,8 @@ public class Push {
     /// The channel sending the Push
     public weak var channel: Channel?
 
-    /// The event, for example `phx_join`
-    public let event: String
+    /// The event, for example `ChannelEvent.join`
+    public let event: ChannelEvent
 
     /// The payload, for example ["user_id": "abc123"]
     public var payload: [String: Any]
@@ -53,7 +53,7 @@ public class Push {
     var ref: String?
 
     /// The event that is associated with the reference ID of the Push
-    var refEvent: String?
+    var refEvent: ChannelEvent?
 
     /// Initializes a Push
     ///
@@ -62,7 +62,7 @@ public class Push {
     /// - parameter payload: Optional. The Payload to send, e.g. ["user_id": "abc123"]
     /// - parameter timeout: Optional. The push timeout. Default is 10.0s
     init(channel: Channel,
-         event: String,
+         event: ChannelEvent,
          payload: [String: Any] = [:],
          timeout: TimeInterval = Defaults.timeoutInterval)
     {
@@ -214,7 +214,7 @@ public class Push {
             let socket = channel.socket else { return }
 
         let ref = socket.makeRef()
-        let refEvent = channel.replyEventName(ref)
+        let refEvent = ChannelEvent.channelReply(ref)
 
         self.ref = ref
         self.refEvent = refEvent

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -495,7 +495,7 @@ public class RealtimeClient: TransportDelegate {
     /// - parameter ref: Optional. Defaults to nil
     /// - parameter joinRef: Optional. Defaults to nil
     internal func push(topic: String,
-                       event: String,
+                       event: ChannelEvent,
                        payload: [String: Any],
                        ref: String? = nil,
                        joinRef: String? = nil)
@@ -606,7 +606,7 @@ public class RealtimeClient: TransportDelegate {
         // Clear heartbeat ref, preventing a heartbeat timeout disconnect
         if message.ref == pendingHeartbeatRef { pendingHeartbeatRef = nil }
 
-        if message.event == "phx_close" {
+        if message.event == .close {
             print("Close Event Received")
         }
 

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -445,7 +445,7 @@ public class RealtimeClient: TransportDelegate {
     /// - parameter topic: Topic of the channel
     /// - parameter params: Optional. Parameters for the channel
     /// - return: A new channel
-    public func channel(_ topic: String,
+    public func channel(_ topic: ChannelTopic,
                         params: [String: Any] = [:]) -> Channel
     {
         let channel = Channel(topic: topic, params: params, socket: self)
@@ -494,7 +494,7 @@ public class RealtimeClient: TransportDelegate {
     /// - parameter payload:
     /// - parameter ref: Optional. Defaults to nil
     /// - parameter joinRef: Optional. Defaults to nil
-    internal func push(topic: String,
+    internal func push(topic: ChannelTopic,
                        event: ChannelEvent,
                        payload: [String: Any],
                        ref: String? = nil,
@@ -502,7 +502,7 @@ public class RealtimeClient: TransportDelegate {
     {
         let callback: (() throws -> Void) = {
             var body: [String: Any] = [
-                "topic": topic,
+                "topic": topic.raw,
                 "event": event,
                 "payload": payload,
             ]
@@ -672,7 +672,7 @@ public class RealtimeClient: TransportDelegate {
     }
 
     // Leaves any channel that is open that has a duplicate topic
-    internal func leaveOpenTopic(topic: String) {
+    internal func leaveOpenTopic(topic: ChannelTopic) {
         guard
             let dupe = channels.first(where: { $0.topic == topic && ($0.isJoined || $0.isJoining) })
         else { return }
@@ -723,7 +723,7 @@ public class RealtimeClient: TransportDelegate {
 
         // The last heartbeat was acknowledged by the server. Send another one
         pendingHeartbeatRef = makeRef()
-        push(topic: "phoenix",
+        push(topic: .heartbeat,
              event: ChannelEvent.heartbeat,
              payload: [:],
              ref: pendingHeartbeatRef)

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -503,7 +503,7 @@ public class RealtimeClient: TransportDelegate {
         let callback: (() throws -> Void) = {
             var body: [String: Any] = [
                 "topic": topic.raw,
-                "event": event,
+                "event": event.raw,
                 "payload": payload,
             ]
 

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -63,24 +63,32 @@ final class RealtimeTests: XCTestCase {
         allChanges.on(.all) { message in
             print(message)
         }
+        allChanges.subscribe()
+        allChanges.unsubscribe()
         allChanges.off(.all)
 
         let allPublicInsertChanges = client.channel(.schema("public"))
         allPublicInsertChanges.on(.insert) { message in
             print(message)
         }
+        allPublicInsertChanges.subscribe()
+        allPublicInsertChanges.unsubscribe()
         allPublicInsertChanges.off(.insert)
 
         let allUsersUpdateChanges = client.channel(.table("users", schema: "public"))
         allUsersUpdateChanges.on(.update) { message in
             print(message)
         }
+        allUsersUpdateChanges.subscribe()
+        allUsersUpdateChanges.unsubscribe()
         allUsersUpdateChanges.off(.update)
 
         let allUserId99Changes = client.channel(.column("id", value: "99", table: "users", schema: "public"))
         allUserId99Changes.on(.all){ message in
             print(message)
         }
+        allUserId99Changes.subscribe()
+        allUserId99Changes.unsubscribe()
         allUserId99Changes.off(.all)
 
         XCTAssertEqual(client.isConnected, false)

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -18,8 +18,7 @@ final class RealtimeTests: XCTestCase {
         }
     }
 
-    var socket = RealtimeClient("https://galflylhyokjtdotwnde.supabase.co/realtime/v1", params: ["apikey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYwODI3ODIyNCwiZXhwIjoxOTIzODU0MjI0fQ.SaWTr6MKjcSCXSnylOrTjHBOt6oU-e82oRPhddMEu4U"])
-//    var socket = RealtimeClient("\(supabaseUrl())/realtime/v1", params: ["apikey": supabaseKey()])
+   var socket = RealtimeClient(endPoint: "\(supabaseUrl())/realtime/v1", params: ["apikey": supabaseKey()])
 
     func testConnection() {
         let e = expectation(description: "testConnection")

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -24,7 +24,9 @@ final class RealtimeTests: XCTestCase {
         let e = expectation(description: "testConnection")
         socket.onOpen { [self] in
             XCTAssertEqual(socket.isConnected, true)
-            socket.disconnect()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                socket.disconnect()
+            }
         }
 
         socket.onError { error in
@@ -40,12 +42,78 @@ final class RealtimeTests: XCTestCase {
 
         waitForExpectations(timeout: 3000) { error in
             if let error = error {
-                XCTFail("testConnection failed: \(error.localizedDescription)")
+                XCTFail("\(self.name)) failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func testTopicSerialization() {
+        XCTAssertEqual(ChannelTopic.all.raw, "realtime:*")
+        XCTAssertEqual(ChannelTopic.schema("public").raw,
+                       "realtime:public")
+        XCTAssertEqual(ChannelTopic.table("users", schema: "public").raw,
+                       "realtime:public:users")
+        XCTAssertEqual(ChannelTopic.column("id", value: "99", table: "users", schema: "public").raw,
+                       "realtime:public:users:id=eq.99")
+    }
+
+    func testChannelCreation() {
+        let client = RealtimeClient(endPoint: "\(Self.supabaseUrl())/realtime/v1", params: ["apikey": Self.supabaseKey()])
+        let allChanges = client.channel(.all)
+        allChanges.on(.all) { message in
+            print(message)
+        }
+        allChanges.off(.all)
+
+        let allPublicInsertChanges = client.channel(.schema("public"))
+        allPublicInsertChanges.on(.insert) { message in
+            print(message)
+        }
+        allPublicInsertChanges.off(.insert)
+
+        let allUsersUpdateChanges = client.channel(.table("users", schema: "public"))
+        allUsersUpdateChanges.on(.update) { message in
+            print(message)
+        }
+        allUsersUpdateChanges.off(.update)
+
+        let allUserId99Changes = client.channel(.column("id", value: "99", table: "users", schema: "public"))
+        allUserId99Changes.on(.all){ message in
+            print(message)
+        }
+        allUserId99Changes.off(.all)
+
+        XCTAssertEqual(client.isConnected, false)
+
+        let e = expectation(description: self.name)
+        client.onOpen { [self] in
+            XCTAssertEqual(client.isConnected, true)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                client.disconnect()
+            }
+        }
+
+        client.onError { error in
+            XCTFail(error.localizedDescription)
+        }
+
+        client.onClose { [self] in
+            XCTAssertEqual(client.isConnected, false)
+            e.fulfill()
+        }
+
+        client.connect()
+
+        waitForExpectations(timeout: 3000) { error in
+            if let error = error {
+                XCTFail("\(self.name)) failed: \(error.localizedDescription)")
             }
         }
     }
 
     static var allTests = [
         ("testConnection", testConnection),
+        ("testTopicSerialization", testTopicSerialization),
+        ("testChannelCreation", testChannelCreation),
     ]
 }


### PR DESCRIPTION
Apply the usual Swift pattern to the API: Event and Topic are now proper Swift Enum.
Limit the current implementation to the effectively supported features.
Extend the tests to ensure the patterns are right.
Add the subscription part to the README for ease of introduction to the framework.