### PR TITLE
Remove realtime: when comparing type parts. 

### DIFF
--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -163,7 +163,7 @@ public enum ChannelTopic {
         } else if type == "phoenix" {
             self = .heartbeat
         } else {
-            let parts = type.split(separator: ":")
+            let parts = type.replacingOccurrences(of: "realtime:", with: "").split(separator: ":")
             switch parts.count {
             case 1:
                 self = .schema(String(parts[0]))


### PR DESCRIPTION
this removes the "realtime:" from the public init call at line 160 that was preventing schema, table, and column listener events. 