### PR TITLE
Fix ChannelTopic init from string and add unit tests

### DIFF
--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -70,7 +70,7 @@ public enum ChannelState: String {
 /// Represents the different events that can be sent through
 /// a channel regarding a Channel's lifecycle or
 /// that can be registered to be notified of.
-public enum ChannelEvent {
+public enum ChannelEvent: RawRepresentable {
     case heartbeat
     case join
     case leave
@@ -85,7 +85,7 @@ public enum ChannelEvent {
 
     case channelReply(String)
 
-    public var raw: String {
+    public var rawValue: String {
         switch self {
         case .heartbeat: return "heartbeat"
         case .join: return "phx_join"
@@ -103,8 +103,8 @@ public enum ChannelEvent {
         }
     }
 
-    public init?(from type: String) {
-        switch type.lowercased() {
+    public init?(rawValue: String) {
+        switch rawValue.lowercased() {
         case "heartbeat": self = .heartbeat
         case "phx_join": self = .join
         case "phx_leave": self = .leave
@@ -124,22 +124,12 @@ public enum ChannelEvent {
         switch event {
         case .join, .leave, .reply, .error, .close: return true
         case .heartbeat, .all, .insert, .update, .delete, .channelReply: return false
-        // Most likely new events will be about notification
-        // not about lifecycle.
-        @unknown default: return false
         }
     }
 }
 
-extension ChannelEvent: Equatable {
-    public static func ==(lhs: ChannelEvent, rhs: ChannelEvent) -> Bool {
-        return lhs.raw == rhs.raw
-    }
-}
-
-/// Represents the different topic
-// a channel can subscribe to.
-public enum ChannelTopic {
+/// Represents the different topic a channel can subscribe to.
+public enum ChannelTopic: RawRepresentable, Equatable {
     case all
     case schema(_ schema: String)
     case table(_ table: String, schema: String)
@@ -147,7 +137,7 @@ public enum ChannelTopic {
 
     case heartbeat
 
-    public var raw: String {
+    public var rawValue: String {
         switch self {
         case .all: return "realtime:*"
         case .schema(let name): return "realtime:\(name)"
@@ -157,13 +147,13 @@ public enum ChannelTopic {
         }
     }
 
-    public init?(from type: String) {
-        if type == "realtime:*" || type == "*" {
+    public init?(rawValue: String) {
+        if rawValue == "realtime:*" || rawValue == "*" {
             self = .all
-        } else if type == "phoenix" {
+        } else if rawValue == "phoenix" {
             self = .heartbeat
         } else {
-            let parts = type.split(separator: ":")
+            let parts = rawValue.replacingOccurrences(of: "realtime:", with: "").split(separator: ":")
             switch parts.count {
             case 1:
                 self = .schema(String(parts[0]))
@@ -181,11 +171,5 @@ public enum ChannelTopic {
                 return nil
             }
         }
-    }
-}
-
-extension ChannelTopic {
-    public static func ==(lhs: ChannelTopic, rhs: ChannelTopic) -> Bool {
-        return lhs.raw == rhs.raw
     }
 }

--- a/Sources/Realtime/Message.swift
+++ b/Sources/Realtime/Message.swift
@@ -67,8 +67,8 @@ public class Message {
             let event = json["event"] as? String,
             let payload = json["payload"] as? [String: Any]
         {
-            self.topic = ChannelTopic(from: topic) ?? .all
-            self.event = ChannelEvent(from: event) ?? .all
+            self.topic = ChannelTopic(rawValue: topic) ?? .all
+            self.event = ChannelEvent(rawValue: event) ?? .all
             self.payload = payload
         } else {
             return nil

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -502,8 +502,8 @@ public class RealtimeClient: TransportDelegate {
     {
         let callback: (() throws -> Void) = {
             var body: [String: Any] = [
-                "topic": topic.raw,
-                "event": event.raw,
+                "topic": topic.rawValue,
+                "event": event.rawValue,
                 "payload": payload,
             ]
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import RealtimeTests
-
-var tests = [XCTestCaseEntry]()
-tests += RealtimeTests.allTests()
-XCTMain(tests)

--- a/Tests/RealtimeTests/ChannelTopicTests.swift
+++ b/Tests/RealtimeTests/ChannelTopicTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import Realtime
+
+final class ChannelTopicTests: XCTestCase {
+
+    func testRawValue() {
+        XCTAssertEqual(ChannelTopic.all, ChannelTopic(rawValue: "realtime:*"))
+        XCTAssertEqual(ChannelTopic.all, ChannelTopic(rawValue: "*"))
+        XCTAssertEqual(ChannelTopic.schema("public"), ChannelTopic(rawValue: "realtime:public"))
+        XCTAssertEqual(
+            ChannelTopic.table("users", schema: "public"), ChannelTopic(rawValue: "realtime:public:users")
+        )
+        XCTAssertEqual(
+            ChannelTopic.column("email", value: "mail@supabase.io", table: "users", schema: "public"),
+            ChannelTopic(rawValue: "realtime:public:users:email=eq.mail@supabase.io"))
+        XCTAssertEqual(ChannelTopic.heartbeat, ChannelTopic(rawValue: "phoenix"))
+    }
+}

--- a/Tests/RealtimeTests/RealtimeTests.swift
+++ b/Tests/RealtimeTests/RealtimeTests.swift
@@ -47,16 +47,6 @@ final class RealtimeTests: XCTestCase {
         }
     }
 
-    func testTopicSerialization() {
-        XCTAssertEqual(ChannelTopic.all.raw, "realtime:*")
-        XCTAssertEqual(ChannelTopic.schema("public").raw,
-                       "realtime:public")
-        XCTAssertEqual(ChannelTopic.table("users", schema: "public").raw,
-                       "realtime:public:users")
-        XCTAssertEqual(ChannelTopic.column("id", value: "99", table: "users", schema: "public").raw,
-                       "realtime:public:users:id=eq.99")
-    }
-
     func testChannelCreation() {
         let client = RealtimeClient(endPoint: "\(Self.supabaseUrl())/realtime/v1", params: ["apikey": Self.supabaseKey()])
         let allChanges = client.channel(.all)
@@ -118,10 +108,4 @@ final class RealtimeTests: XCTestCase {
             }
         }
     }
-
-    static var allTests = [
-        ("testConnection", testConnection),
-        ("testTopicSerialization", testTopicSerialization),
-        ("testChannelCreation", testChannelCreation),
-    ]
 }

--- a/Tests/RealtimeTests/XCTestManifests.swift
+++ b/Tests/RealtimeTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-    public func allTests() -> [XCTestCaseEntry] {
-        return [
-            testCase(RealtimeTests.allTests),
-        ]
-    }
-#endif


### PR DESCRIPTION
I created this PR in favor of #4 . Thanks @lmick002 for addressing it, I've just added a few minor things on top of it, such as:

1. Refactoring `ChannelTopic` type for using `RawRepresentable`.
2. Add unit tests for testing the `ChannelTopic` init from the rawValue string.

Fixes #3 
