### PR TITLE
Import FoundationNetworking if needed.

### DIFF
--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -39,6 +39,9 @@
 // THE SOFTWARE.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// ## RealtimeClient
 ///

--- a/Sources/Realtime/Transport.swift
+++ b/Sources/Realtime/Transport.swift
@@ -19,6 +19,9 @@
 // THE SOFTWARE.
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Starscream
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Add `FoundationNetworking` if available.
This is allowing Linux platforms to compile the framework, since the migration of URL-related function to the `FoundationNetworking` framework.