### PR TITLE
Remove RealtimeClient endpoint parameter name underscore prefix from initializers

### DIFF
--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -192,21 +192,6 @@ public class RealtimeClient: TransportDelegate {
       vsn: vsn
     )
   }
-  
-  @available(*, deprecated, renamed: "init(_:paramsClosure:vsn:)")
-  public convenience init(
-    endPoint: String,
-    paramsClosure: PayloadClosure?,
-    vsn: String = Defaults.vsn
-  ) {
-    self.init(
-      endPoint: endPoint,
-      transport: { url in URLSessionTransport(url: url) },
-      paramsClosure: paramsClosure,
-      vsn: vsn
-    )
-  }
-
 
   public init(
     endPoint: String,

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -167,7 +167,7 @@ public class RealtimeClient: TransportDelegate {
   // ----------------------------------------------------------------------
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
-    endPoint: String,
+    _ endPoint: String,
     params: Payload? = nil,
     vsn: String = Defaults.vsn
   ) {
@@ -181,7 +181,7 @@ public class RealtimeClient: TransportDelegate {
 
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
-    endPoint: String,
+    _ endPoint: String,
     paramsClosure: PayloadClosure?,
     vsn: String = Defaults.vsn
   ) {

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -167,7 +167,7 @@ public class RealtimeClient: TransportDelegate {
   // ----------------------------------------------------------------------
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
-    _ endPoint: String,
+    endPoint: String,
     params: Payload? = nil,
     vsn: String = Defaults.vsn
   ) {
@@ -181,7 +181,7 @@ public class RealtimeClient: TransportDelegate {
 
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   public convenience init(
-    _ endPoint: String,
+    endPoint: String,
     paramsClosure: PayloadClosure?,
     vsn: String = Defaults.vsn
   ) {

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -192,6 +192,21 @@ public class RealtimeClient: TransportDelegate {
       vsn: vsn
     )
   }
+  
+  @available(*, deprecated, renamed: "init(_:paramsClosure:vsn:)")
+  public convenience init(
+    endPoint: String,
+    paramsClosure: PayloadClosure?,
+    vsn: String = Defaults.vsn
+  ) {
+    self.init(
+      endPoint: endPoint,
+      transport: { url in URLSessionTransport(url: url) },
+      paramsClosure: paramsClosure,
+      vsn: vsn
+    )
+  }
+
 
   public init(
     endPoint: String,

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -192,6 +192,21 @@ public class RealtimeClient: TransportDelegate {
       vsn: vsn
     )
   }
+    
+  @available(*, deprecated, renamed: "init(_:params:vsn:)")
+  public convenience init(
+    endPoint: String,
+    params: Payload? = nil,
+    vsn: String = Defaults.vsn
+  ) {
+    self.init(
+      endPoint: endPoint,
+      transport: { url in URLSessionTransport(url: url) },
+      paramsClosure: { params },
+      vsn: vsn
+    )
+  }
+    
 
   public init(
     endPoint: String,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes the `_` prefix from the RealtimeClient initializers

## What is the current behavior?
RealtimeClient initializer has parameter with underscore prefix
```swift
init(_ endpoint: String, ...)
```

[SupabaseClient](https://github.com/supabase-community/supabase-swift/blob/master/Sources/Supabase/SupabaseClient.swift) initializer in `main` branch of supabase-swift uses `endpoint` without `_` prefix.
```swift
/// Realtime client for Supabase
  public var realtime: RealtimeClient {
    RealtimeClient(
      endPoint: realtimeURL.absoluteString,
      params: defaultHeaders
    )
  }
```


## What is the new behavior?

Remove `_` prefix from RealtimeClient Initializers.
```swift
init(endpoint: String, ...)
```

## Additional context

This fix for #21 should enable usage in current version (0.3.0) of `supabase-swift`