### PR TITLE
fix fatal error passing in non supported types to JSONSerialization.data

### DIFF
--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -45,7 +45,8 @@ public enum Defaults {
 
   /// Default encode function, utilizing JSONSerialization.data
   public static let encode: (Any) -> Data = { json in
-    try! JSONSerialization
+    assert(JSONSerialization.isValidJSONObject(json), "Invalid JSON object")
+    return try! JSONSerialization
       .data(
         withJSONObject: json,
         options: JSONSerialization.WritingOptions()

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -645,7 +645,7 @@ public class RealtimeClient: TransportDelegate {
     joinRef: String? = nil
   ) {
     let callback: (() throws -> Void) = {
-      let body: [Any?] = [joinRef, ref, topic, event, payload]
+      let body: [Any?] = [joinRef, ref, topic.rawValue, event.rawValue, payload]
       let data = self.encode(body)
 
       self.logItems("push", "Sending \(String(data: data, encoding: String.Encoding.utf8) ?? "")")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Currently `RealtimeClient.push` passes unsupported types to `JSONSerialzation.data` causing an fatal exception `JSONSerialization Invalid type in JSON write (_SwiftValue)`. According to apple docs for [JSONSerialization](https://developer.apple.com/documentation/foundation/jsonserialization) the only supported types are `NSArray`, `NSDictionary`, `NSString`, `NSNumber`, `NSArray`, `NSDictionary`, or `NSNull`, but RealtimeClient.push is passing in types `ChannelEvent` and `ChannelTopic`.
```swift
internal func push(
    topic: ChannelTopic,
    event: ChannelEvent,
    payload: Payload,
    ref: String? = nil,
    joinRef: String? = nil
  ) {
    // ... hidden for illustrative purposes
      let body: [Any?] = [joinRef, ref, topic, event, payload]
      let data = self.encode(body)
    // ... hidden for illustrative purposes
}
```

## What is the new behavior?
Instead of passing `event: ChannelEvent` and `topic: ChannelTopic` directly, pass in their rawValue attribute since they conform to `RawRepresentable`
```swift
internal func push(
    topic: ChannelTopic,
    event: ChannelEvent,
    payload: Payload,
    ref: String? = nil,
    joinRef: String? = nil
  ) {
    // ... hidden for illustrative purposes
      let body: [Any?] = [joinRef, ref, topic.rawValue, event.rawValue, payload]
      let data = self.encode(body)
    // ... hidden for illustrative purposes
}
```
## Additional Context
The reason `realtime-swift` throws an exception but `SwiftPhoenixClient` does not is because `event` and `topic` are already encoded as `String` types (see [Socket.swift](https://github.com/davidstump/SwiftPhoenixClient/blob/master/Sources/SwiftPhoenixClient/Socket.swift) from `realtime-swift` master)
```swift
internal func push(topic: String,
                   event: String,
                   payload: Payload,
                   ref: String? = nil,
                   joinRef: String? = nil) {
    
    // ... hidden for illustrative purposes
      let body: [Any?] = [joinRef, ref, topic, event, payload]
      let data = self.encode(body)
    // ... hidden for illustrative purposes
}
```