### PR TITLE
Automatically inject options into Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,23 @@ allUserId99Changes.subscribe()
 allUserId99Changes.unsubscribe()
 allUserId99Changes.off(.all)
 ```
+### Presence
 
+Presence can be used to share state between clients.
+
+* Listen to presence `sync` events:
+
+```swift
+let channel = client.channel(.table("channel_id", schema: "someChannel"), options: .init(presenceKey: "user_uuid"))
+let presence = Presence(channel: channel)
+
+presence.onSync {
+    print("presence sync", presence?.state, presence?.list())
+}
+
+channel.join()
+// ...
+```
 
 ## Credits
 

--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -94,11 +94,30 @@ public class Channel {
   var stateChangeRefs: [String]
 
   /// Initialize a Channel
+  /// - parameter topic: Topic of the Channel
+  /// - parameter options: Optional. Options to configure channel broadcast and presence
+  /// - parameter socket: Socket that the channel is a part of
+  public convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient) {
+    let params = [
+      "config": [
+        "presence": [
+          "key": options.presenceKey ?? ""
+        ],
+        "broadcast": [
+          "ack": options.broadcastAcknowledge,
+          "self": options.broadcastSelf
+        ]
+      ]
+    ]
+    self.init(topic: topic, params: params, socket: socket)
+  }
+  
+  /// Initialize a Channel
   ///
   /// - parameter topic: Topic of the Channel
   /// - parameter params: Optional. Parameters to send when joining.
   /// - parameter socket: Socket that the channel is a part of
-  init(topic: ChannelTopic, params: [String: Any] = [:], socket: RealtimeClient) {
+  init(topic: ChannelTopic, params: [String:Any], socket: RealtimeClient) {
     state = ChannelState.closed
     self.topic = topic
     self.params = params

--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -117,7 +117,7 @@ public class Channel {
   /// - parameter topic: Topic of the Channel
   /// - parameter params: Optional. Parameters to send when joining.
   /// - parameter socket: Socket that the channel is a part of
-  init(topic: ChannelTopic, params: [String:Any], socket: RealtimeClient) {
+  init(topic: ChannelTopic, params: [String: Any], socket: RealtimeClient) {
     state = ChannelState.closed
     self.topic = topic
     self.params = params

--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -198,3 +198,19 @@ public enum ChannelTopic: RawRepresentable, Equatable {
     }
   }
 }
+
+/// Represents the broadcast and presence options for a channel.
+public struct ChannelOptions {
+  /// Used to track presence payload across clients. Must be unique per client. If `nil`, the server will generate one.
+  var presenceKey: String?
+  /// Enables the client to receieve their own`broadcast` messages
+  var broadcastSelf: Bool
+  /// Instructs the server to acknoledge the client's `broadcast` messages
+  var broadcastAcknowledge: Bool
+    
+  public init(presenceKey: String? = nil, broadcastSelf: Bool = false, broadcastAcknowledge: Bool = false) {
+    self.presenceKey = presenceKey
+    self.broadcastSelf = broadcastSelf
+    self.broadcastAcknowledge = broadcastAcknowledge
+  }
+}

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -583,7 +583,24 @@ public class RealtimeClient: TransportDelegate {
   // ----------------------------------------------------------------------
 
   // MARK: - Channel Initialization
-
+  // ----------------------------------------------------------------------
+  /// Initialize a new Channel
+  ///
+  /// Example:
+  ///
+  ///     let channel = socket.channel("rooms", options: ChannelOptions(presenceKey: "user123"))
+  ///
+  /// - parameter topic: Topic of the channel
+  /// - parameter options: Optional. Options for the channel
+  /// - return: A new channel
+  public func channel(
+    _ topic: ChannelTopic,
+    options: ChannelOptions = ChannelOptions()
+  ) -> Channel {
+    let channel = Channel(topic: topic, options: options, socket: self)
+    channels.append(channel)
+    return channel
+  }
   // ----------------------------------------------------------------------
   /// Initialize a new Channel
   ///
@@ -594,9 +611,10 @@ public class RealtimeClient: TransportDelegate {
   /// - parameter topic: Topic of the channel
   /// - parameter params: Optional. Parameters for the channel
   /// - return: A new channel
+  @available(*, deprecated, renamed: "channel(_:options:)")
   public func channel(
     _ topic: ChannelTopic,
-    params: [String: Any] = [:]
+    params: [String: Any]
   ) -> Channel {
     let channel = Channel(topic: topic, params: params, socket: self)
     channels.append(channel)


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature, add docs

## What is the current behavior?

`Channel` initializer has parameter `params` of type `[String:Any]`. When `params` is unset this prevents channel `Presence` from receiving `sync` events. See my [earlier comment](https://github.com/supabase-community/realtime-swift/pull/21#issuecomment-1661151037) in discussion #21 for more details.

## What is the new behavior?

`Channel` initializer has new parameter `options` of type `ChannelOptions` allowing `Presence` to receive `sync` events by default.

## Additional context

`ChannelOptions` was generated using types found in [RealtimeChannelOptions](https://github.com/supabase/realtime-js/blob/c9dc9c953cb6bb3e9440749d393e944b63a0a0f9/src/RealtimeChannel.ts#L14-L28)
