### PR TITLE
remove public accessor from channel convenience init

### DIFF
--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -97,7 +97,7 @@ public class Channel {
   /// - parameter topic: Topic of the Channel
   /// - parameter options: Optional. Options to configure channel broadcast and presence
   /// - parameter socket: Socket that the channel is a part of
-  public convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient) {
+  convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient) {
     let params = [
       "config": [
         "presence": [


### PR DESCRIPTION
## What kind of change does this PR introduce?

update

## What is the current behavior?

```swift
public convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient)
```

## What is the new behavior?

```swift
convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient)
```

## Additional context

Came about because of [comment](https://github.com/supabase-community/realtime-swift/pull/24#discussion_r1281562098) by @grsouza 
