### PR TITLE
Bugfix: unable to listen postgres changes on channel.

### DIFF
--- a/Sources/Realtime/Channel.swift
+++ b/Sources/Realtime/Channel.swift
@@ -95,21 +95,10 @@ public class Channel {
 
   /// Initialize a Channel
   /// - parameter topic: Topic of the Channel
-  /// - parameter options: Optional. Options to configure channel broadcast and presence
+  /// - parameter options: Optional. Options to configure channel broadcast and presence. Leave nil for postgres channel.
   /// - parameter socket: Socket that the channel is a part of
-  convenience init(topic: ChannelTopic, options: ChannelOptions = ChannelOptions(), socket: RealtimeClient) {
-    let params = [
-      "config": [
-        "presence": [
-          "key": options.presenceKey ?? ""
-        ],
-        "broadcast": [
-          "ack": options.broadcastAcknowledge,
-          "self": options.broadcastSelf
-        ]
-      ]
-    ]
-    self.init(topic: topic, params: params, socket: socket)
+  convenience init(topic: ChannelTopic, options: ChannelOptions? = nil, socket: RealtimeClient) {
+    self.init(topic: topic, params: options?.params ?? [:], socket: socket)
   }
   
   /// Initialize a Channel

--- a/Sources/Realtime/Defaults.swift
+++ b/Sources/Realtime/Defaults.swift
@@ -233,6 +233,22 @@ public struct ChannelOptions {
     self.broadcastSelf = broadcastSelf
     self.broadcastAcknowledge = broadcastAcknowledge
   }
+  
+  /// Parameters used to configure the channel
+  var params: [String: [String: Any]] {
+    [
+      "config": [
+        "presence": [
+          "key": presenceKey ?? ""
+        ],
+        "broadcast": [
+          "ack": broadcastAcknowledge,
+          "self": broadcastSelf
+        ]
+      ]
+    ]
+  }
+
 }
 
 /// Represents the different status of a push

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -590,11 +590,11 @@ public class RealtimeClient: TransportDelegate {
   ///     let channel = socket.channel("rooms", options: ChannelOptions(presenceKey: "user123"))
   ///
   /// - parameter topic: Topic of the channel
-  /// - parameter options: Optional. Options for the channel
+  /// - parameter options: Optional. Options to configure channel broadcast and presence. Leave nil for postgres channel.
   /// - return: A new channel
   public func channel(
     _ topic: ChannelTopic,
-    options: ChannelOptions = ChannelOptions()
+    options: ChannelOptions? = nil
   ) -> Channel {
     let channel = Channel(topic: topic, options: options, socket: self)
     channels.append(channel)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When creating a channel to listen to a postgres schema, table, or column. No changes will be receieved by the client due to having a configuration the server is not expecting. The configuration is only expected and should be sent if a channel is meant to be used with Presence or Broadcast API.

## What is the new behavior?

When creating a channel, the options (`ChannelOptions`) parameter will default to nil enabling the client to receive postgres changes. However if Broadcast or Presence is desired, options can be passed in like previous commit 0d3eea773c37e9cf346789c0ba7f030a524ee9ff .

